### PR TITLE
Admob appid showed only when selected

### DIFF
--- a/Assets/ScaleMonk Ads/Editor/AdnetsWindow/AdsProviderWindow.cs
+++ b/Assets/ScaleMonk Ads/Editor/AdnetsWindow/AdsProviderWindow.cs
@@ -114,18 +114,18 @@ namespace ScaleMonk.Ads
                                 }
 
                                 EditorGUILayout.EndHorizontal();
-                            }
-
-                            foreach (var config in adnet.configs)
-                            {
-                                if (config.platform == "ios")
+                                
+                                foreach (var config in adnet.configs)
                                 {
-                                    EditorGUILayout.BeginHorizontal(GUILayout.Width(500));
+                                    if (config.platform == "ios")
                                     {
-                                        GUILayout.Space(10);
-                                        config.value = EditorGUILayout.TextField(config.name, config.value);
+                                        EditorGUILayout.BeginHorizontal(GUILayout.Width(500));
+                                        {
+                                            GUILayout.Space(10);
+                                            config.value = EditorGUILayout.TextField(config.name, config.value);
+                                        }
+                                        EditorGUILayout.EndHorizontal();
                                     }
-                                    EditorGUILayout.EndHorizontal();
                                 }
                             }
                         }
@@ -165,18 +165,18 @@ namespace ScaleMonk.Ads
                                 }
 
                                 EditorGUILayout.EndHorizontal();
-                            }
-
-                            foreach (var config in adnet.configs)
-                            {
-                                if (config.platform == "android")
+                                
+                                foreach (var config in adnet.configs)
                                 {
-                                    EditorGUILayout.BeginHorizontal(GUILayout.Width(500));
+                                    if (config.platform == "android")
                                     {
-                                        GUILayout.Space(10);
-                                        config.value = EditorGUILayout.TextField(config.name, config.value);
+                                        EditorGUILayout.BeginHorizontal(GUILayout.Width(500));
+                                        {
+                                            GUILayout.Space(10);
+                                            config.value = EditorGUILayout.TextField(config.name, config.value);
+                                        }
+                                        EditorGUILayout.EndHorizontal();
                                     }
-                                    EditorGUILayout.EndHorizontal();
                                 }
                             }
                         }

--- a/Assets/ScaleMonk Ads/Editor/AndroidManifestPostGradleProcessor.cs
+++ b/Assets/ScaleMonk Ads/Editor/AndroidManifestPostGradleProcessor.cs
@@ -28,7 +28,7 @@ namespace ScaleMonk_Ads.Editor
             
             foreach (var adnet in scaleMonkXml.adnets)
             {
-                if (adnet.configs == null)
+                if (adnet.configs == null || !adnet.android)
                 {
                     continue;
                 }


### PR DESCRIPTION
Changes:
- Admob's AppID text field is shown only if Admob is selected
- Admob's AppID is added in the manifest only if Admob is selected