### PR TITLE
Add missing methods to check if ads are ready to be shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-Allow configure IAnalytics before and after the initialization
+- Allow configure IAnalytics before and after the initialization
+- Added `IsInterstitialReadyToShow` and `IsRewardedReadyToShow` methods
 
 ### Fixed
-Fix export package. Exclude exporter on export package process
+- Fix export package. Exclude exporter on export package process
 
 ## [1.8.0] - 2021-06-15
 

--- a/Source/Editor/Config.cs
+++ b/Source/Editor/Config.cs
@@ -2,6 +2,6 @@ namespace ScaleMonk.Ads
 {
     public static class Config
     {
-        public static readonly string Version = "1.9.0-rc.1";
+        public static readonly string Version = "1.10.0-rc.1";
     }
 }

--- a/Source/Source/Android/AdsAndroidBinding.cs
+++ b/Source/Source/Android/AdsAndroidBinding.cs
@@ -53,7 +53,7 @@ namespace ScaleMonk.Ads.Android
 
         public bool IsRewardedVideoReadyToShow(string tag)
         {
-            return _androidJavaBridge.CallBooleanNativeMethod("isRewardedVideoReadyToShow", tag);
+            return _androidJavaBridge.CallBooleanNativeMethod("isRewardedReadyToShow", tag);
         }
 
         public bool AreRewardedEnabled()

--- a/Source/Source/Android/AdsBinding.java
+++ b/Source/Source/Android/AdsBinding.java
@@ -16,7 +16,12 @@ import com.unity3d.player.UnityPlayer;
 
 import org.jetbrains.annotations.NotNull;
 import androidx.annotation.Keep;
+
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RunnableFuture;
+
+import static com.unity3d.services.core.misc.Utilities.runOnUiThread;
 
 @Keep
 public class AdsBinding {
@@ -43,12 +48,36 @@ public class AdsBinding {
 
     public boolean isInterstitialReadyToShow(String tag) {
         Log.d(TAG, "Checking availability of interstitials at: " + tag + ".");
-        return ScaleMonkAds.isInterstitialReadyToShow(tag);
+
+        boolean[] result = new boolean[1];
+
+        RunnableFuture<Void> task = new FutureTask<>(() -> result[0] = ScaleMonkAds.isInterstitialReadyToShow(tag), null);
+        runOnUiThread(task);
+
+        try {
+            task.get(); // this will block until Runnable completes
+        } catch (Exception e) {
+            result[0] = false;
+        }
+
+        return result[0];
     }
 
     public boolean isRewardedReadyToShow(String tag) {
         Log.d(TAG, "Checking availability of videos on: " + tag + ".");
-        return ScaleMonkAds.isRewardedReadyToShow(tag);
+
+        boolean[] result = new boolean[1];
+
+        RunnableFuture<Void> task = new FutureTask<>(() -> result[0] = ScaleMonkAds.isRewardedReadyToShow(tag), null);
+        runOnUiThread(task);
+
+        try {
+            task.get(); // this will block until Runnable completes
+        } catch (Exception e) {
+            result[0] = false;
+        }
+
+        return result[0];
     }
 
 //    public boolean areVideosEnabled() {

--- a/Source/Source/ScaleMonkAdsSDK.cs
+++ b/Source/Source/ScaleMonkAdsSDK.cs
@@ -181,6 +181,13 @@ namespace ScaleMonk.Ads
         }
 
         /// <summary>
+        /// Returns true if there is an instance of interstitial ad ready to be shown. Otherwise, it returns false.
+        ///
+        /// </summary>
+        /// <param name="tag">The game tag from where the ad will be displayed (like menu or store).</param>
+        public bool IsInterstitialReadyToShow(string tag) => _adsBinding.IsInterstitialReadyToShow(tag);
+
+        /// <summary>
         /// Displays a rewarded ad.
         ///
         /// If the display was successful, the event `RewardedDisplayedEvent` will be called when the ad closes.
@@ -206,6 +213,13 @@ namespace ScaleMonk.Ads
                 _adsBinding.ShowRewarded(tag);
             });
         }
+
+        /// <summary>
+        /// Returns true if there is an instance of rewarded ad ready to be shown. Otherwise, it returns false.
+        ///
+        /// </summary>
+        /// <param name="tag">The game tag from where the ad will be displayed (like menu or store).</param>
+        public bool IsRewardedReadyToShow(string tag) => _adsBinding.IsRewardedVideoReadyToShow(tag);
 
         /// <summary>
         /// Displays a banner ad.


### PR DESCRIPTION
Added the bindings to call native methods `IsRewardedReadyToShow` and `IsInterstitialReadyToShow`. Both methods must be called on the UI Thread.

I'll add these changes to the Unity public docs.