### PR TITLE
Coppa/ios binding enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Adds binding for `setIsApplicationChildDirected` with coppa enum on android
 
+### Changed
+- Adds binding for `setIsApplicationChildDirectedStatus` with coppa enum on ios
+
 ## [1.8.0] - 2021-06-15
 
 ### Changed

--- a/Source/Source/iOS/AdsBinding.m
+++ b/Source/Source/iOS/AdsBinding.m
@@ -6,6 +6,7 @@
 //
 
 #import <ScaleMonkAds/SMAds.h>
+#import <ScaleMonkAds/SMRegulationsConstants.h>
 #import "AdsBindingRewardedDelegateViewController.h"
 #import "AdsBindingInterstitialViewController.h"
 #import "AdsBindingBannerViewController.h"
@@ -218,14 +219,18 @@ void SMSetApplicationChildDirected(bool isChildDirected){
 }
 
 void SMSetApplicationChildDirectedStatus(int status){
-    // Enum is not implemented yet on iOS side.
-    // this should be mapped to the future CoppaStatus enum
     switch(status) {
+        case 0:
+            [smAds setIsApplicationChildDirectedStatus: CoppaStatusTypeUnknown];
+            break;
         case 1:
-            [smAds setIsApplicationChildDirected: false];
+            [smAds setIsApplicationChildDirectedStatus: CoppaStatusTypeChildTreatmentFalse];
             break;
         case 2:
-            [smAds setIsApplicationChildDirected: true];
+            [smAds setIsApplicationChildDirectedStatus: CoppaStatusTypeChildTreatmentTrue];
+            break;
+        case 3:
+            [smAds setIsApplicationChildDirectedStatus: CoppaStatusTypeNotApplicable];
             break;
     }
 }


### PR DESCRIPTION
# Summary
  * Adds binding for ios to coppa enum

Only to be merged when [https://github.com/scalemonk/mediation-sdk-unity/pull/59](https://github.com/scalemonk/mediation-sdk-unity/pull/59) gets merged, and change it to target `master`