### PR TITLE
Add flag to post processor to enable facebook login 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 - The binding for setCustomSegmentationTags
 
+## [1.14.1]
+### Fixed
+- Fixed typo in iOS post processor script. Changed `Admob` to `AdMob`
+
 ## [1.14.0] - 2021-08-25
 ### Changed
 - Updated Android ScaleMonk version to 6.1.0

--- a/Source/Editor/Config.cs
+++ b/Source/Editor/Config.cs
@@ -2,6 +2,6 @@ namespace ScaleMonk.Ads
 {
     public static class Config
     {
-        public static readonly string Version = "1.14.0";
+        public static readonly string Version = "1.14.1-alpha.1";
     }
 }

--- a/Source/Editor/ScaleMonkAdsiOSPostProcessor.cs
+++ b/Source/Editor/ScaleMonkAdsiOSPostProcessor.cs
@@ -62,7 +62,7 @@ namespace ScaleMonk.Ads
                         }
                     }
                     
-                    if (adnet.id == "Admob")
+                    if (adnet.id == "AdMob")
                     {
                         disableAdmobSwizzling(infoPlist);
                     }


### PR DESCRIPTION
### Changes 

Fix typo from `Admob` to `AdMob` in iOS post processor script.