### PR TITLE
Prepare the release 9.0.0

### DIFF
--- a/2019-Container/ProjectSettings/AndroidResolverDependencies.xml
+++ b/2019-Container/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,14 +1,16 @@
 <dependencies>
   <packages>
-    <package>com.scalemonk.libs:ads:8.0.0</package>
+    <package>com.scalemonk.libs:ads:9.0.0</package>
     <package>com.scalemonk.libs:ads-adcolony:+</package>
     <package>com.scalemonk.libs:ads-admob:+</package>
     <package>com.scalemonk.libs:ads-applovin:+</package>
     <package>com.scalemonk.libs:ads-chartboost:+</package>
     <package>com.scalemonk.libs:ads-facebook:+</package>
     <package>com.scalemonk.libs:ads-fyber:+</package>
+    <package>com.scalemonk.libs:ads-hyprmx:+</package>
     <package>com.scalemonk.libs:ads-inmobi:+</package>
     <package>com.scalemonk.libs:ads-ironsource:+</package>
+    <package>com.scalemonk.libs:ads-maio:+</package>
     <package>com.scalemonk.libs:ads-mintegral:+</package>
     <package>com.scalemonk.libs:ads-mopub:+</package>
     <package>com.scalemonk.libs:ads-mytarget:+</package>
@@ -16,6 +18,7 @@
     <package>com.scalemonk.libs:ads-tiktok:+</package>
     <package>com.scalemonk.libs:ads-unityads:+</package>
     <package>com.scalemonk.libs:ads-vungle:+</package>
+    <package>com.scalemonk.libs:ads-yandex:+</package>
   </packages>
   <files />
   <settings>

--- a/Source/Editor/AdnetsWindow/AdsProvidersHelper.cs
+++ b/Source/Editor/AdnetsWindow/AdsProvidersHelper.cs
@@ -17,7 +17,7 @@ namespace ScaleMonk.Ads
     public class AdsProvidersHelper
     {
         const string iosAdsVersion = "5.0.0";
-        const string androidAdsVersion = "8.0.0";
+        const string androidAdsVersion = "9.0.0";
       
         public static string GetAdnetsXmlPath()
         {
@@ -334,12 +334,13 @@ namespace ScaleMonk.Ads
                 {
                     "mintegral", new List<string>
                     {
-                        "https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea",
                         "https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea"
                     }
                 },
-                {"ironsource", new List<string> {"https://android-sdk.is.com/"}},
-                {"smaato", new List<string> {"https://s3.amazonaws.com/smaato-sdk-releases/"}},
+                {"ironsource", new List<string> {"https://android-sdk.is.com"}},
+                {"smaato", new List<string> {"https://s3.amazonaws.com/smaato-sdk-releases"}},
+                {"maio", new List<string> {"https://imobile-maio.github.io/maven"}},
+                {"hyprmx", new List<string> {"https://hyprmx.jfrog.io/artifactory/hyprmx"}}
             };
 
             var repositories = doc.CreateElement("repositories");

--- a/Source/Editor/Config.cs
+++ b/Source/Editor/Config.cs
@@ -2,6 +2,6 @@ namespace ScaleMonk.Ads
 {
     public static class Config
     {
-        public static readonly string Version = "1.21.0";
+        public static readonly string Version = "1.22.0";
     }
 }

--- a/Source/Editor/ScaleMonkAdsDependencies.xml
+++ b/Source/Editor/ScaleMonkAdsDependencies.xml
@@ -1,15 +1,17 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <dependencies>
   <androidPackages>
-    <androidPackage spec="com.scalemonk.libs:ads:8.0.0" />
+    <androidPackage spec="com.scalemonk.libs:ads:9.0.0" />
     <androidPackage spec="com.scalemonk.libs:ads-adcolony:+" />
     <androidPackage spec="com.scalemonk.libs:ads-admob:+" />
     <androidPackage spec="com.scalemonk.libs:ads-applovin:+" />
     <androidPackage spec="com.scalemonk.libs:ads-chartboost:+" />
     <androidPackage spec="com.scalemonk.libs:ads-facebook:+" />
     <androidPackage spec="com.scalemonk.libs:ads-fyber:+" />
+    <androidPackage spec="com.scalemonk.libs:ads-hyprmx:+" />
     <androidPackage spec="com.scalemonk.libs:ads-inmobi:+" />
     <androidPackage spec="com.scalemonk.libs:ads-ironsource:+" />
+    <androidPackage spec="com.scalemonk.libs:ads-maio:+" />
     <androidPackage spec="com.scalemonk.libs:ads-mintegral:+" />
     <androidPackage spec="com.scalemonk.libs:ads-mopub:+" />
     <androidPackage spec="com.scalemonk.libs:ads-mytarget:+" />
@@ -17,16 +19,18 @@
     <androidPackage spec="com.scalemonk.libs:ads-tiktok:+" />
     <androidPackage spec="com.scalemonk.libs:ads-unityads:+" />
     <androidPackage spec="com.scalemonk.libs:ads-vungle:+" />
+    <androidPackage spec="com.scalemonk.libs:ads-yandex:+" />
     <repositories>
       <repository>https://scalemonk.jfrog.io/artifactory/scalemonk-gradle-prod</repository>
-      <repository>https://android-sdk.is.com/</repository>
+      <repository>https://hyprmx.jfrog.io/artifactory/hyprmx</repository>
+      <repository>https://android-sdk.is.com</repository>
+      <repository>https://imobile-maio.github.io/maven</repository>
       <repository>https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea</repository>
-      <repository>https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea</repository>
-      <repository>https://s3.amazonaws.com/smaato-sdk-releases/</repository>
+      <repository>https://s3.amazonaws.com/smaato-sdk-releases</repository>
     </repositories>
   </androidPackages>
   <iosPods>
-    <iosPod name="ScaleMonkAds" version="3.1.0">
+    <iosPod name="ScaleMonkAds" version="5.0.0">
       <sources>
         <source>https://github.com/scalemonk/ios-podspecs-framework</source>
       </sources>
@@ -66,12 +70,22 @@
         <source>https://github.com/scalemonk/ios-podspecs-framework</source>
       </sources>
     </iosPod>
+    <iosPod name="ScaleMonkAds-HyprMX">
+      <sources>
+        <source>https://github.com/scalemonk/ios-podspecs-framework</source>
+      </sources>
+    </iosPod>
     <iosPod name="ScaleMonkAds-InMobi">
       <sources>
         <source>https://github.com/scalemonk/ios-podspecs-framework</source>
       </sources>
     </iosPod>
     <iosPod name="ScaleMonkAds-IronSource">
+      <sources>
+        <source>https://github.com/scalemonk/ios-podspecs-framework</source>
+      </sources>
+    </iosPod>
+    <iosPod name="ScaleMonkAds-Maio">
       <sources>
         <source>https://github.com/scalemonk/ios-podspecs-framework</source>
       </sources>
@@ -112,6 +126,11 @@
       </sources>
     </iosPod>
     <iosPod name="ScaleMonkAds-Vungle">
+      <sources>
+        <source>https://github.com/scalemonk/ios-podspecs-framework</source>
+      </sources>
+    </iosPod>
+    <iosPod name="ScaleMonkAds-Yandex">
       <sources>
         <source>https://github.com/scalemonk/ios-podspecs-framework</source>
       </sources>


### PR DESCRIPTION
- Upgrades Android Ads-Core major version: `9.0.0`.
- Adds new adnets: `maio`, `hyprmx`, `yandex`.
- Adds repositories for new adnets, and ironSource that was missing for some reason.