### PR TITLE
Analytics use native implementation now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Changed
+- Analytics use native implementation now
 
 ## [1.22.0] - 2021-11-09
 ### Changed

--- a/Source/Source/Android/AdsBindingAnalyticsListener.java
+++ b/Source/Source/Android/AdsBindingAnalyticsListener.java
@@ -4,40 +4,25 @@ import android.app.Activity;
 import android.content.Context;
 import androidx.annotation.Keep;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import com.scalemonk.libs.ads.core.domain.Analytics;
+import com.tfg.libs.analytics.AnalyticsManager;
 import com.unity3d.player.UnityPlayer;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 
 @Keep
 public class AdsBindingAnalyticsListener implements Analytics {
-    private Gson gson;
-
-    public AdsBindingAnalyticsListener() {
-        gson = new GsonBuilder().create();
-    }
-
+    
     @Override
     public void sendEvent(@NotNull String eventName, @NotNull Map<String, ?> eventParams) {
-        JsonObject eventAsJson = new JsonObject();
-        ArrayList<String> eventKeys = new ArrayList<>();
-        ArrayList<Object> eventValues = new ArrayList<>();
-
-        for (Map.Entry<String, ?> entry : eventParams.entrySet()) {
-            eventKeys.add(entry.getKey());
-            eventValues.add(entry.getValue());
+        Map<String, String> map = new HashMap<>();
+        for (Map.Entry<String, ?> entry : params.entrySet()) {
+            map.put(entry.getKey(), entry.getValue().toString());
         }
-        eventAsJson.addProperty("eventName", eventName);
-        eventAsJson.add("eventKeys", gson.toJsonTree(eventKeys).getAsJsonArray());
-        eventAsJson.add("eventValues", gson.toJsonTree(eventValues).getAsJsonArray());
 
-        UnityPlayer.UnitySendMessage("AdsMonoBehaviour", "SendEvent", eventAsJson.toString());
+        AnalyticsManager.getInstance().sendEvent(eventName, map);
     }
 }

--- a/Source/Source/iOS/AdsBindingAnalyticsViewController.m
+++ b/Source/Source/iOS/AdsBindingAnalyticsViewController.m
@@ -6,6 +6,7 @@
 //
 
 #import "AdsBindingAnalyticsViewController.h"
+#import "TFGAnalytics.h"
 
 @interface AdsBindingAnalyticsViewController ()
 
@@ -23,30 +24,17 @@
     @try {
         NSLog(@"Event %@ received on iOS binding", eventName);
 
-        NSString * eventAsString = createEventAsString(eventName, eventParams);
+        NSArray *eventKeys = eventParams.allKeys;
+        NSMutableArray* eventValues = [[NSMutableArray alloc] init];
 
-        UnitySendMessage("AdsMonoBehaviour", "SendEvent", strdup([eventAsString UTF8String]));
+        for(id key in eventParams)
+            [eventValues addObject: [NSString stringWithFormat: @"%@", [eventParams objectForKey: key]]];
+            
+        [[TFGAnalytics sharedInstance] sendEvent:eventName params:  [[NSMutableDictionary alloc] initWithObjects:eventValues forKeys:eventKeys]];
     }
     @catch(id exception){
-        NSLog(@"Cannot serialize event %@ with params %@ into json %@", eventName, eventParams, exception);
+        NSLog(@"Cannot serialize event %@ with params %@ error is %@", eventName, eventParams, exception);
     }
-}
-
-static NSString *createEventAsString(NSString *eventName, NSDictionary<NSString *,NSObject *> *eventParams) {
-    NSError *error;
-    NSArray *eventKeys = eventParams.allKeys;
-    NSArray *eventValues = eventParams.allValues;
-    
-    NSDictionary *dict = [[NSDictionary alloc] initWithObjectsAndKeys:eventName, @"eventName", eventKeys, @"eventKeys",
-                          eventValues, @"eventValues", nil];
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict options:NSJSONWritingPrettyPrinted error:&error];
-    if (error != nil) {
-        NSLog(@"Cannot serialize event into json %@", error);
-        return @"";
-    }
-
-    NSString* jsonDictionary = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    return jsonDictionary;
 }
 
 @end


### PR DESCRIPTION
UnitySendMessage should not be used for sending analytics. It is causing the UnityMain thread to be unavailable to receive events from the Billing and Ads SDK.
The new implementation relies on the native implementation to send the events