### PR TITLE
Moved ScaleMonkAds.initialize to a background thread

### DIFF
--- a/Source/Source/Android/AdsBinding.java
+++ b/Source/Source/Android/AdsBinding.java
@@ -47,9 +47,7 @@ public class AdsBinding {
     }
 
     public void initialize() {
-        this.activity.runOnUiThread(() -> {
-            setupAds(interstitialListener, videoListener, bannerListener);
-        });
+        Executors.newSingleThreadExecutor().execute(() -> setupAds(interstitialListener, videoListener, bannerListener));
     }
 
     public boolean isInterstitialReadyToShow(String tag) {


### PR DESCRIPTION
Moved ScaleMonkAds.initialize to a background thread because running on main is not needed.

This was tested by showing ads on Sniper3D local build.
Also profiled before and after to see that the execution is no longer on the main thread.

Attached is a screenshot showing that the SDK's initialization is being executed on a new thread:
<img width="559" alt="Screen Shot 2021-11-24 at 15 39 44" src="https://user-images.githubusercontent.com/74210795/143296205-b7861c45-9dab-4290-a2ef-0ceb1ad1a1ea.png">
