### PR TITLE
Fix typo on parameter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.25.1]
+### Added
+- Fixed typo in Analytics binding param
 
 ## [1.25.0]
 ### Added

--- a/Source/Source/Android/AdsBindingAnalyticsListener.java
+++ b/Source/Source/Android/AdsBindingAnalyticsListener.java
@@ -19,7 +19,7 @@ public class AdsBindingAnalyticsListener implements Analytics {
     @Override
     public void sendEvent(@NotNull String eventName, @NotNull Map<String, ?> eventParams) {
         Map<String, String> map = new HashMap<>();
-        for (Map.Entry<String, ?> entry : params.entrySet()) {
+        for (Map.Entry<String, ?> entry : eventParams.entrySet()) {
             map.put(entry.getKey(), entry.getValue().toString());
         }
 


### PR DESCRIPTION
Package 1.25.0 was released with a typo on a parameter of the Analytics Binding for Android.
